### PR TITLE
Maven Dependency for Java1.9+

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,16 @@ Depend on development snapshots with the following `pom.xml` entries:
 </dependencies>
 ```
 
+Note that the SDK is written to be used with Java version 1.8. If you're using any Java version beginning from 1.9, ensure to add the following dependency:
+
+```xml
+<dependency>
+    <groupId>javax.xml.bind</groupId>
+    <artifactId>jaxb-api</artifactId>
+    <version>2.3.1</version>
+</dependency>
+```
+
 ### Gradle
 
 Depend on development snapshots with the following `build.gradle` entries:
@@ -104,6 +114,7 @@ dependencies {
     implementation 'org.hyperledger.fabric-gateway-java:fabric-gateway-java:1.4.0-SNAPSHOT'
 }
 ```
+
 
 ## Building and testing
 


### PR DESCRIPTION
Beginning with Java 1.9 the jaxb-api is not included in the JDK by default anymore. See this post: http://openjdk.java.net/jeps/320
Thus, it has to be included in pom.xml.
The project  explicitly either explicitly mention that the SDK is for Java version 1.8 or it should include this dependency in the pom.xml.