### PR TITLE
Configure Junit display name generator

### DIFF
--- a/src/test/resources/junit-platform.properties
+++ b/src/test/resources/junit-platform.properties
@@ -1,0 +1,1 @@
+junit.jupiter.displayname.generator.default = org.junit.jupiter.api.DisplayNameGenerator$ReplaceUnderscores


### PR DESCRIPTION
Use the default ReplaceUnderscores display name generator, which
replaces underscores in test method names with spaces to improve
readability.

Signed-off-by: Mark S. Lewis <mark_lewis@uk.ibm.com>