### PR TITLE
FGJ-66: Fix API doc links

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ class Sample {
 ### API documentation
 
 Full Javadoc documentation is published for each of the following versions:
-- [1.4](https://hyperledger.github.io/fabric-gateway-java/release-1.4)
-- [2.0 (beta)](https://hyperledger.github.io/fabric-gateway-java/master)
+- [1.4](https://hyperledger.github.io/fabric-gateway-java/release-1.4/)
+- [2.0 (beta)](https://hyperledger.github.io/fabric-gateway-java/master/)
 
 ### Maven
 

--- a/scripts/ci_scripts/publishJavaApiDocs.sh
+++ b/scripts/ci_scripts/publishJavaApiDocs.sh
@@ -47,11 +47,9 @@ cleanStaging() {
 }
 
 removeStagingRootFiles() {
-    local rootFile
-    find "${STAGING_DIR}" -type f -maxdepth 1 -mindepth 1 -print | while read -r rootFile; do
-        echo "Removing ${rootFile}"
-        rm -f "${rootFile}"
-    done
+    find "${STAGING_DIR}" -type f -maxdepth 1 -mindepth 1 \
+        -exec echo Removing {} \; \
+        -exec rm -f {} \;
 }
 
 copyToStaging() {


### PR DESCRIPTION
Trailing slashes are required to ensure the link is treated as a
directory rather than a file.

Signed-off-by: Mark S. Lewis <mark_lewis@uk.ibm.com>