### PR TITLE
FGJ-70: Remove compile warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,6 +137,14 @@
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.8.0</version>
+                    <configuration>
+                        <showDeprecation>true</showDeprecation>
+                        <showWarnings>true</showWarnings>
+                        <compilerArgs>
+                            <arg>-Xlint</arg>
+                            <arg>-Werror</arg>
+                        </compilerArgs>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>

--- a/src/main/java/org/hyperledger/fabric/gateway/ContractException.java
+++ b/src/main/java/org/hyperledger/fabric/gateway/ContractException.java
@@ -16,6 +16,8 @@ import org.hyperledger.fabric.sdk.ProposalResponse;
  * Thrown when an error occurs invoking a smart contract.
  */
 public class ContractException extends GatewayException {
+    private static final long serialVersionUID = -1278679656087547825L;
+
     private Collection<ProposalResponse> proposalResponses;
 
     /**

--- a/src/main/java/org/hyperledger/fabric/gateway/GatewayException.java
+++ b/src/main/java/org/hyperledger/fabric/gateway/GatewayException.java
@@ -10,6 +10,8 @@ package org.hyperledger.fabric.gateway;
  * Base class for exceptions thrown by the Gateway SDK or by components of the underlying Fabric.
  */
 public class GatewayException extends Exception {
+    private static final long serialVersionUID = -6313392932347237084L;
+
     /**
      * Constructs a new exception with the specified detail message. The cause is not initialized.
      * @param message the detail message.

--- a/src/main/java/org/hyperledger/fabric/gateway/GatewayRuntimeException.java
+++ b/src/main/java/org/hyperledger/fabric/gateway/GatewayRuntimeException.java
@@ -10,6 +10,8 @@ package org.hyperledger.fabric.gateway;
  * Runtime exception for gateway classes. Typically indicates misconfiguration or misuse of the API.
  */
 public class GatewayRuntimeException extends RuntimeException {
+    private static final long serialVersionUID = -1051523683665686266L;
+
     /**
      * Constructs a new exception with the specified detail message. The cause is not initialized.
      * @param message the detail message.

--- a/src/main/java/org/hyperledger/fabric/gateway/impl/TransactionImpl.java
+++ b/src/main/java/org/hyperledger/fabric/gateway/impl/TransactionImpl.java
@@ -22,7 +22,6 @@ import org.hyperledger.fabric.gateway.spi.CommitHandler;
 import org.hyperledger.fabric.gateway.spi.CommitHandlerFactory;
 import org.hyperledger.fabric.gateway.spi.Query;
 import org.hyperledger.fabric.gateway.spi.QueryHandler;
-import org.hyperledger.fabric.sdk.ChaincodeID;
 import org.hyperledger.fabric.sdk.ChaincodeResponse;
 import org.hyperledger.fabric.sdk.Channel;
 import org.hyperledger.fabric.sdk.Peer;
@@ -170,13 +169,17 @@ public final class TransactionImpl implements Transaction {
     }
 
     private void configureRequest(final TransactionRequest request, final String... args) {
+        // Replace setChaincodeID() with setChaincodeName() once the low-level SDK allows this for transaction
+        // invocations using service discovery
         request.setChaincodeID(getChaincodeId());
+//        request.setChaincodeName(contract.getChaincodeId());
         request.setFcn(name);
         request.setArgs(args);
     }
 
-    private ChaincodeID getChaincodeId() {
-        return ChaincodeID.newBuilder()
+    @SuppressWarnings("deprecation")
+    private org.hyperledger.fabric.sdk.ChaincodeID getChaincodeId() {
+        return org.hyperledger.fabric.sdk.ChaincodeID.newBuilder()
                 .setName(contract.getChaincodeId())
                 .build();
     }

--- a/src/main/java/org/hyperledger/fabric/gateway/impl/identity/FileSystemWalletStore.java
+++ b/src/main/java/org/hyperledger/fabric/gateway/impl/identity/FileSystemWalletStore.java
@@ -41,7 +41,7 @@ public final class FileSystemWalletStore implements WalletStore {
     }
 
     @Override
-    public InputStream get(final String label) throws IOException {
+    public InputStream get(final String label) {
         try {
             return Files.newInputStream(getPathForLabel(label));
         } catch (IOException e) {

--- a/src/main/java/org/hyperledger/fabric/gateway/impl/identity/X509IdentityProvider.java
+++ b/src/main/java/org/hyperledger/fabric/gateway/impl/identity/X509IdentityProvider.java
@@ -88,7 +88,7 @@ public enum X509IdentityProvider implements IdentityProvider<X509Identity> {
         }
     }
 
-    private X509Identity newIdentity(final JsonObject identityData) throws CertificateException, InvalidKeyException, IOException {
+    private X509Identity newIdentity(final JsonObject identityData) throws CertificateException, InvalidKeyException {
         String mspId = identityData.getString(IdentityConstants.JSON_MSP_ID);
 
         JsonObject credentials = identityData.getJsonObject(JSON_CREDENTIALS);

--- a/src/test/java/org/hyperledger/fabric/gateway/IdentitiesTest.java
+++ b/src/test/java/org/hyperledger/fabric/gateway/IdentitiesTest.java
@@ -21,6 +21,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class IdentitiesTest {
+    private static final TestUtils testUtils = TestUtils.getInstance();
+
     private final X509Credentials credentials = new X509Credentials();
     private final String x509CertificatePem = "-----BEGIN CERTIFICATE-----\n" +
             "MIICGDCCAb+gAwIBAgIQHWBLQRSL/SxAckSUBCAceDAKBggqhkjOPQQDAjBzMQsw\n" +
@@ -45,15 +47,7 @@ public class IdentitiesTest {
     @Test
     public void certificate_read_error_throws_IOException() {
         String failMessage = "read failure";
-        Reader reader = new Reader() {
-            @Override
-            public int read(char[] cbuf, int offset, int length) throws IOException {
-                throw new IOException(failMessage);
-            }
-
-            @Override
-            public void close() { }
-        };
+        Reader reader = testUtils.newFailingReader(failMessage);
 
         assertThatThrownBy(() -> Identities.readX509Certificate(reader))
                 .isInstanceOf(IOException.class)
@@ -79,15 +73,7 @@ public class IdentitiesTest {
     @Test
     public void private_key_read_error_throws_IOException() {
         String failMessage = "read failure";
-        Reader reader = new Reader() {
-            @Override
-            public int read(char[] cbuf, int offset, int length) throws IOException {
-                throw new IOException(failMessage);
-            }
-
-            @Override
-            public void close() { }
-        };
+        Reader reader = testUtils.newFailingReader(failMessage);
 
         assertThatThrownBy(() -> Identities.readPrivateKey(reader))
                 .isInstanceOf(IOException.class)

--- a/src/test/java/org/hyperledger/fabric/gateway/TestUtils.java
+++ b/src/test/java/org/hyperledger/fabric/gateway/TestUtils.java
@@ -7,6 +7,7 @@
 package org.hyperledger.fabric.gateway;
 
 import java.io.IOException;
+import java.io.Reader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -51,7 +52,7 @@ public final class TestUtils {
 
     private TestUtils() { }
 
-    public GatewayImpl.Builder newGatewayBuilder() throws GatewayException, OperatorCreationException, CertificateException, NoSuchAlgorithmException, NoSuchProviderException, IOException {
+    public GatewayImpl.Builder newGatewayBuilder() throws IOException {
         X509Credentials credentials = new X509Credentials();
 
         GatewayImpl.Builder builder = (GatewayImpl.Builder)Gateway.createBuilder();
@@ -71,7 +72,7 @@ public final class TestUtils {
         return builder;
     }
 
-    public HFClient newMockClient() throws OperatorCreationException, CertificateException, NoSuchAlgorithmException, NoSuchProviderException, IOException {
+    public HFClient newMockClient() {
         X509Credentials credentials = new X509Credentials();
         Enrollment enrollment = new X509Enrollment(credentials.getPrivateKey(), credentials.getCertificatePem());
         User user = new GatewayUser("user", "msp1", enrollment);
@@ -306,4 +307,21 @@ public final class TestUtils {
         return tempDir;
     }
 
+    /**
+     * Create a new Reader instance that will fail on any read attempt with the provided exception message.
+     * @param failMessage Read exception message.
+     * @return A reader.
+     */
+    public Reader newFailingReader(final String failMessage) {
+        return new Reader() {
+            @Override
+            public int read(char[] cbuf, int offset, int length) throws IOException {
+                throw new IOException(failMessage);
+            }
+
+            @Override
+            public void close() {
+            }
+        };
+    }
 }

--- a/src/test/java/org/hyperledger/fabric/gateway/X509Credentials.java
+++ b/src/test/java/org/hyperledger/fabric/gateway/X509Credentials.java
@@ -57,8 +57,8 @@ public final class X509Credentials {
 
     private X509Certificate generateCertificate(KeyPair keyPair) {
         X500Name dnName = new X500Name("CN=John Doe");
-        Date validityBeginDate = new Date(System.currentTimeMillis() - 24 * 60 * 60 * 1000); // Yesterday
-        Date validityEndDate = new Date(System.currentTimeMillis() + 2 * 365 * 24 * 60 * 60 * 1000); // 2 years from now
+        Date validityBeginDate = new Date(System.currentTimeMillis() - 24L * 60 * 60 * 1000); // Yesterday
+        Date validityEndDate = new Date(System.currentTimeMillis() + 2L * 365 * 24 * 60 * 60 * 1000); // 2 years from now
         SubjectPublicKeyInfo subPubKeyInfo = SubjectPublicKeyInfo.getInstance(keyPair.getPublic().getEncoded());
         X509v3CertificateBuilder builder = new X509v3CertificateBuilder(
                 dnName,

--- a/src/test/java/org/hyperledger/fabric/gateway/impl/BlockListenerTest.java
+++ b/src/test/java/org/hyperledger/fabric/gateway/impl/BlockListenerTest.java
@@ -139,7 +139,7 @@ public class BlockListenerTest {
     }
 
     @Test
-    public void add_checkpoint_listener_returns_the_listener() throws GatewayException, IOException {
+    public void add_checkpoint_listener_returns_the_listener() throws IOException {
         Consumer<BlockEvent> listener = blockEvent -> {};
         Checkpointer checkpointer = new InMemoryCheckpointer();
 
@@ -149,7 +149,7 @@ public class BlockListenerTest {
     }
 
     @Test
-    public void listener_with_new_checkpointer_receives_events() throws GatewayException, IOException {
+    public void listener_with_new_checkpointer_receives_events() throws IOException {
         Consumer<BlockEvent> listener = Mockito.spy(testUtils.stubBlockListener());
         Checkpointer checkpointer = new InMemoryCheckpointer();
         BlockEvent event = testUtils.newMockBlockEvent(peer1, 2);
@@ -161,7 +161,7 @@ public class BlockListenerTest {
     }
 
     @Test
-    public void removed_checkpoint_listener_does_not_receive_events() throws GatewayException, IOException {
+    public void removed_checkpoint_listener_does_not_receive_events() throws IOException {
         Consumer<BlockEvent> listener = Mockito.spy(testUtils.stubBlockListener());
         Checkpointer checkpointer = new InMemoryCheckpointer();
         BlockEvent event = testUtils.newMockBlockEvent(peer1, 2);
@@ -174,7 +174,7 @@ public class BlockListenerTest {
     }
 
     @Test
-    public void listener_with_saved_checkpointer_resumes_from_previous_event() throws GatewayException, IOException {
+    public void listener_with_saved_checkpointer_resumes_from_previous_event() throws IOException {
         Consumer<BlockEvent> listener = Mockito.spy(testUtils.stubBlockListener());
         Checkpointer checkpointer = new InMemoryCheckpointer();
         BlockEvent event1 = testUtils.newMockBlockEvent(peer1, 1);
@@ -191,7 +191,7 @@ public class BlockListenerTest {
     }
 
     @Test
-    public void add_replay_listener_returns_the_listener() throws GatewayException, IOException {
+    public void add_replay_listener_returns_the_listener() {
         Consumer<BlockEvent> listener = blockEvent -> {};
 
         Consumer<BlockEvent> result = network.addBlockListener(1, listener);
@@ -200,7 +200,7 @@ public class BlockListenerTest {
     }
 
     @Test
-    public void replay_listener_receives_replay_events() throws GatewayException, IOException {
+    public void replay_listener_receives_replay_events() {
         Consumer<BlockEvent> realtimeListener = event -> {};
         Consumer<BlockEvent> replayListener = Mockito.spy(testUtils.stubBlockListener());
         BlockEvent event1 = testUtils.newMockBlockEvent(peer1, 1);

--- a/src/test/java/org/hyperledger/fabric/gateway/impl/ContractListenerTest.java
+++ b/src/test/java/org/hyperledger/fabric/gateway/impl/ContractListenerTest.java
@@ -81,14 +81,6 @@ public class ContractListenerTest {
         return result;
     }
 
-    private ChaincodeEvent mockChaincodeEvent(String chaincodeId, String name, byte[] payload) {
-        ChaincodeEvent result = mock(ChaincodeEvent.class);
-        when(result.getChaincodeId()).thenReturn(chaincodeId);
-        when(result.getEventName()).thenReturn(name);
-        when(result.getPayload()).thenReturn(payload);
-        return result;
-    }
-
     private void fireEvents(ChaincodeEvent... chaincodeEvents) {
         BlockEvent event = newBlockEvent(1, chaincodeEvents);
         blockSource.sendEvent(event);
@@ -254,7 +246,7 @@ public class ContractListenerTest {
     }
 
     @Test
-    public void add_checkpoint_listener_returns_the_listener() throws IOException, GatewayException {
+    public void add_checkpoint_listener_returns_the_listener() throws IOException {
         Consumer<ContractEvent> listener = event -> {};
         Checkpointer checkpointer = new InMemoryCheckpointer();
 
@@ -264,7 +256,7 @@ public class ContractListenerTest {
     }
 
     @Test
-    public void add_checkpoint_listener_with_event_name_returns_the_listener() throws IOException, GatewayException {
+    public void add_checkpoint_listener_with_event_name_returns_the_listener() throws IOException {
         Consumer<ContractEvent> listener = event -> {};
         Checkpointer checkpointer = new InMemoryCheckpointer();
 
@@ -274,7 +266,7 @@ public class ContractListenerTest {
     }
 
     @Test
-    public void add_checkpoint_listener_with_event_pattern_returns_the_listener() throws IOException, GatewayException {
+    public void add_checkpoint_listener_with_event_pattern_returns_the_listener() throws IOException {
         Consumer<ContractEvent> listener = event -> {};
         Checkpointer checkpointer = new InMemoryCheckpointer();
 
@@ -284,7 +276,7 @@ public class ContractListenerTest {
     }
 
     @Test
-    public void listener_with_new_checkpointer_receives_all_events() throws IOException, GatewayException {
+    public void listener_with_new_checkpointer_receives_all_events() throws IOException {
         Consumer<ContractEvent> listener = spy(testUtils.stubContractListener());
         Checkpointer checkpointer = new InMemoryCheckpointer();
         ChaincodeEvent chaincodeEvent1 = mockChaincodeEvent(chaincodeId, eventName + 1);
@@ -298,7 +290,7 @@ public class ContractListenerTest {
     }
 
     @Test
-    public void listener_with_saved_checkpointer_resumes_from_previous_event() throws IOException, GatewayException {
+    public void listener_with_saved_checkpointer_resumes_from_previous_event() throws IOException {
         Consumer<ContractEvent> realtimeListener = event -> {};
         Consumer<ContractEvent> replayListener = spy(testUtils.stubContractListener());
         Checkpointer checkpointer = new InMemoryCheckpointer();
@@ -317,7 +309,7 @@ public class ContractListenerTest {
     }
 
     @Test
-    public void listener_with_new_checkpointer_only_receives_events_with_specific_name() throws IOException, GatewayException {
+    public void listener_with_new_checkpointer_only_receives_events_with_specific_name() throws IOException {
         Consumer<ContractEvent> listener = spy(testUtils.stubContractListener());
         Checkpointer checkpointer = new InMemoryCheckpointer();
         ChaincodeEvent badEvent = mockChaincodeEvent(chaincodeId, "BAD_" + eventName);
@@ -331,7 +323,7 @@ public class ContractListenerTest {
     }
 
     @Test
-    public void listener_with_new_checkpointer_only_receives_events_matching_a_pattern() throws IOException, GatewayException {
+    public void listener_with_new_checkpointer_only_receives_events_matching_a_pattern() throws IOException {
         Consumer<ContractEvent> listener = spy(testUtils.stubContractListener());
         Checkpointer checkpointer = new InMemoryCheckpointer();
         ChaincodeEvent badEvent = mockChaincodeEvent(chaincodeId, "BAD_" + eventName);
@@ -346,7 +338,7 @@ public class ContractListenerTest {
     }
 
     @Test
-    public void add_replay_listener_returns_the_listener() throws IOException, GatewayException {
+    public void add_replay_listener_returns_the_listener() {
         Consumer<ContractEvent> listener = event -> {};
 
         Consumer<ContractEvent> result = contract.addContractListener(1, listener);
@@ -355,7 +347,7 @@ public class ContractListenerTest {
     }
 
     @Test
-    public void add_replay_listener_with_event_name_returns_the_listener() throws IOException, GatewayException {
+    public void add_replay_listener_with_event_name_returns_the_listener() {
         Consumer<ContractEvent> listener = event -> {};
 
         Consumer<ContractEvent> result = contract.addContractListener(1, listener, eventName);
@@ -364,7 +356,7 @@ public class ContractListenerTest {
     }
 
     @Test
-    public void add_replay_listener_with_event_pattern_returns_the_listener() throws IOException, GatewayException {
+    public void add_replay_listener_with_event_pattern_returns_the_listener() {
         Consumer<ContractEvent> listener = event -> {};
 
         Consumer<ContractEvent> result = contract.addContractListener(1, listener, eventNamePattern);
@@ -373,7 +365,7 @@ public class ContractListenerTest {
     }
 
     @Test
-    public void replay_listener_receives_events_from_start_block() throws IOException, GatewayException {
+    public void replay_listener_receives_events_from_start_block() {
         Consumer<ContractEvent> replayListener = spy(testUtils.stubContractListener());
         ChaincodeEvent chaincodeEvent = mockChaincodeEvent(chaincodeId, eventName);
         BlockEvent blockEvent1 = newBlockEvent(1, chaincodeEvent);
@@ -389,7 +381,7 @@ public class ContractListenerTest {
     }
 
     @Test
-    public void replay_listener_with_event_name_receives_events_from_start_block() throws IOException, GatewayException {
+    public void replay_listener_with_event_name_receives_events_from_start_block() {
         Consumer<ContractEvent> replayListener = spy(testUtils.stubContractListener());
         ChaincodeEvent goodEvent = mockChaincodeEvent(chaincodeId, eventName);
         ChaincodeEvent badEvent = mockChaincodeEvent(chaincodeId, "BAD_" + eventName);
@@ -408,7 +400,7 @@ public class ContractListenerTest {
     }
 
     @Test
-    public void replay_listener_with_event_pattern_receives_events_from_start_block() throws IOException, GatewayException {
+    public void replay_listener_with_event_pattern_receives_events_from_start_block() {
         Consumer<ContractEvent> replayListener = spy(testUtils.stubContractListener());
         ChaincodeEvent goodEvent = mockChaincodeEvent(chaincodeId, eventName);
         ChaincodeEvent badEvent = mockChaincodeEvent(chaincodeId, "BAD_" + eventName);

--- a/src/test/java/org/hyperledger/fabric/gateway/impl/GatewayBuilderTest.java
+++ b/src/test/java/org/hyperledger/fabric/gateway/impl/GatewayBuilderTest.java
@@ -63,7 +63,7 @@ public class GatewayBuilderTest {
     }
 
     @Test
-    public void testBuilderInvalidIdentity() throws IOException {
+    public void testBuilderInvalidIdentity() {
         assertThatThrownBy(() -> builder.identity(testWallet, "INVALID_IDENTITY"))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("INVALID_IDENTITY");

--- a/src/test/java/org/hyperledger/fabric/gateway/impl/GatewayTest.java
+++ b/src/test/java/org/hyperledger/fabric/gateway/impl/GatewayTest.java
@@ -28,7 +28,7 @@ public class GatewayTest {
     }
 
     @Test
-    public void testGetNetworkFromConfig() throws GatewayException {
+    public void testGetNetworkFromConfig() {
         try (Gateway gateway = builder.connect()) {
             Network network = gateway.getNetwork("mychannel");
             assertThat(network.getChannel().getName()).isEqualTo("mychannel");
@@ -36,7 +36,7 @@ public class GatewayTest {
     }
 
     @Test
-    public void testGetAssumedNetwork() throws Exception {
+    public void testGetAssumedNetwork() {
         try (Gateway gateway = builder.connect()) {
             Network network = gateway.getNetwork("assumed");
             assertThat(network.getChannel().getName()).isEqualTo("assumed");
@@ -44,7 +44,7 @@ public class GatewayTest {
     }
 
     @Test
-    public void testGetCachedNetwork() throws GatewayException {
+    public void testGetCachedNetwork() {
         try (Gateway gateway = builder.connect()) {
             Network network = gateway.getNetwork("assumed");
             Network network2 = gateway.getNetwork("assumed");
@@ -53,7 +53,7 @@ public class GatewayTest {
     }
 
     @Test
-    public void testGetNetworkEmptyString() throws Exception {
+    public void testGetNetworkEmptyString() {
         try (Gateway gateway = builder.connect()) {
             assertThatThrownBy(() -> gateway.getNetwork(""))
                     .isInstanceOf(IllegalArgumentException.class)
@@ -62,7 +62,7 @@ public class GatewayTest {
     }
 
     @Test
-    public void testGetNetworkNullString() throws Exception {
+    public void testGetNetworkNullString() {
         try (Gateway gateway = builder.connect()) {
             assertThatThrownBy(() -> gateway.getNetwork(null))
                     .isInstanceOf(IllegalArgumentException.class)
@@ -71,7 +71,7 @@ public class GatewayTest {
     }
 
     @Test
-    public void testCloseGatewayClosesNetworks() throws Exception {
+    public void testCloseGatewayClosesNetworks() {
         Gateway gateway = builder.connect();
         Channel channel = gateway.getNetwork("assumed").getChannel();
 

--- a/src/test/java/org/hyperledger/fabric/gateway/impl/commit/CommitHandlerImplTest.java
+++ b/src/test/java/org/hyperledger/fabric/gateway/impl/commit/CommitHandlerImplTest.java
@@ -6,7 +6,6 @@
 
 package org.hyperledger.fabric.gateway.impl.commit;
 
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -18,8 +17,6 @@ import org.hyperledger.fabric.gateway.Gateway;
 import org.hyperledger.fabric.gateway.GatewayException;
 import org.hyperledger.fabric.gateway.Network;
 import org.hyperledger.fabric.gateway.TestUtils;
-import org.hyperledger.fabric.gateway.impl.commit.CommitHandlerImpl;
-import org.hyperledger.fabric.gateway.impl.commit.CommitStrategy;
 import org.hyperledger.fabric.gateway.impl.event.StubBlockEventSource;
 import org.hyperledger.fabric.gateway.impl.event.StubPeerDisconnectEventSource;
 import org.hyperledger.fabric.gateway.spi.CommitHandler;

--- a/src/test/java/org/hyperledger/fabric/gateway/impl/event/ChannelBlockEventSourceTest.java
+++ b/src/test/java/org/hyperledger/fabric/gateway/impl/event/ChannelBlockEventSourceTest.java
@@ -107,7 +107,7 @@ public class ChannelBlockEventSourceTest {
     }
 
     @Test
-    public void forwards_channel_block_events_to_listener() throws Exception {
+    public void forwards_channel_block_events_to_listener() {
         Consumer<BlockEvent> listener = spy(testUtils.stubBlockListener());
         BlockEvent blockEvent = mock(BlockEvent.class);
 

--- a/src/test/java/org/hyperledger/fabric/gateway/impl/identity/X509IdentityProviderTest.java
+++ b/src/test/java/org/hyperledger/fabric/gateway/impl/identity/X509IdentityProviderTest.java
@@ -64,7 +64,7 @@ public class X509IdentityProviderTest {
     }
 
     @Test
-    public void from_JSON_with_invalid_type_ID_throws_IOException() throws CertificateException, InvalidKeyException, IOException {
+    public void from_JSON_with_invalid_type_ID_throws_IOException() {
         JsonObject jsonData = Json.createObjectBuilder(jsonV1())
                 .add("type", "BAD_TYPE")
                 .build();
@@ -75,7 +75,7 @@ public class X509IdentityProviderTest {
     }
 
     @Test
-    public void from_JSON_with_invalid_version_throws_IOException() throws CertificateException, InvalidKeyException, IOException {
+    public void from_JSON_with_invalid_version_throws_IOException() {
         JsonObject jsonData = Json.createObjectBuilder(jsonV1())
                 .add("version", Integer.MAX_VALUE)
                 .build();
@@ -86,7 +86,7 @@ public class X509IdentityProviderTest {
     }
 
     @Test
-    public void from_JSON_with_missing_fields_throws_IOException() throws CertificateException, InvalidKeyException, IOException {
+    public void from_JSON_with_missing_fields_throws_IOException() {
         JsonObject jsonData = Json.createObjectBuilder(jsonV1())
                 .remove(IdentityConstants.JSON_MSP_ID)
                 .build();

--- a/src/test/java/org/hyperledger/fabric/gateway/impl/identity/X509IdentityTest.java
+++ b/src/test/java/org/hyperledger/fabric/gateway/impl/identity/X509IdentityTest.java
@@ -28,7 +28,7 @@ public final class X509IdentityTest {
     private static final String mspId = "mspId";
     private static final X509Credentials credentials = new X509Credentials();
 
-    public static Stream<X509Identity> identityProvider() throws CertificateException, InvalidKeyException, IOException {
+    public static Stream<X509Identity> identityProvider() throws CertificateException {
         return Stream.of(
                 newIdentityFromFromCertificateAndPrivateKey(),
                 newIdentityFromEnrollment()

--- a/src/test/java/org/hyperledger/fabric/gateway/impl/query/CommonQueryHandlerTest.java
+++ b/src/test/java/org/hyperledger/fabric/gateway/impl/query/CommonQueryHandlerTest.java
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.hyperledger.fabric.gateway.impl;
+package org.hyperledger.fabric.gateway.impl.query;
 
 import java.util.Arrays;
 import java.util.Collection;

--- a/src/test/java/org/hyperledger/fabric/gateway/impl/query/RoundRobinQueryHandlerTest.java
+++ b/src/test/java/org/hyperledger/fabric/gateway/impl/query/RoundRobinQueryHandlerTest.java
@@ -10,8 +10,6 @@ import java.util.Arrays;
 import java.util.Collection;
 
 import org.hyperledger.fabric.gateway.ContractException;
-import org.hyperledger.fabric.gateway.impl.CommonQueryHandlerTest;
-import org.hyperledger.fabric.gateway.impl.query.RoundRobinQueryHandler;
 import org.hyperledger.fabric.gateway.spi.Query;
 import org.hyperledger.fabric.gateway.spi.QueryHandler;
 import org.hyperledger.fabric.sdk.Peer;

--- a/src/test/java/org/hyperledger/fabric/gateway/impl/query/SingleQueryHandlerTest.java
+++ b/src/test/java/org/hyperledger/fabric/gateway/impl/query/SingleQueryHandlerTest.java
@@ -10,8 +10,6 @@ import java.util.Arrays;
 import java.util.Collection;
 
 import org.hyperledger.fabric.gateway.ContractException;
-import org.hyperledger.fabric.gateway.impl.CommonQueryHandlerTest;
-import org.hyperledger.fabric.gateway.impl.query.SingleQueryHandler;
 import org.hyperledger.fabric.gateway.spi.Query;
 import org.hyperledger.fabric.gateway.spi.QueryHandler;
 import org.hyperledger.fabric.sdk.Peer;

--- a/src/test/java/scenario/ScenarioSteps.java
+++ b/src/test/java/scenario/ScenarioSteps.java
@@ -384,9 +384,7 @@ public class ScenarioSteps implements En {
             wallet.put(label, identity);
         });
 
-        When("I remove an identity named {string} from the wallet", (String label) -> {
-            wallet.remove(label);
-        });
+        When("I remove an identity named {string} from the wallet", (String label) -> wallet.remove(label));
 
         Then("a response should be received", () -> transactionInvocation.getResponse());
 
@@ -591,7 +589,7 @@ public class ScenarioSteps implements En {
         exec(fixtures, "./generate.sh");
     }
 
-    private void populateWallet() throws IOException, GatewayException, CertificateException, InvalidKeyException {
+    private void populateWallet() throws IOException, CertificateException, InvalidKeyException {
         Identity identity = newOrg1UserIdentity();
         wallet.put("User1", identity);
     }


### PR DESCRIPTION
- Remove redundant throws declarations
- Add missing serialVersionUID declarations
- Temporarily suppress warning for deprecated use of ChaincodeID
- Make compile warnings fail the build

Also:
- Move test file to more relevant package
- Remove test code duplication