### PR TITLE
[FGJ-58] Ability to build a gateway without a Wallet

### DIFF
--- a/src/main/java/org/hyperledger/fabric/gateway/Gateway.java
+++ b/src/main/java/org/hyperledger/fabric/gateway/Gateway.java
@@ -133,6 +133,14 @@ public interface Gateway extends AutoCloseable {
         Builder identity(Wallet wallet, String id) throws IOException;
 
         /**
+         * Specifies the identity that is to be used to connect to the network.  All operations
+         * under this gateway connection will be performed using this identity.
+         * @param identity An identity
+         * @return The builder instance, allowing multiple configuration options to be chained.
+         */
+        Builder identity(Identity identity);
+
+        /**
          * <em>Optional</em> - Allows an alternative commit handler to be specified. The commit handler defines how
          * client code should wait to receive commit events from peers following submit of a transaction.
          * <p>Default commit handler implementations are defined in {@link DefaultCommitHandlers}.</p>

--- a/src/main/java/org/hyperledger/fabric/gateway/impl/GatewayImpl.java
+++ b/src/main/java/org/hyperledger/fabric/gateway/impl/GatewayImpl.java
@@ -33,6 +33,7 @@ import org.hyperledger.fabric.gateway.Identities;
 import org.hyperledger.fabric.gateway.Identity;
 import org.hyperledger.fabric.gateway.Network;
 import org.hyperledger.fabric.gateway.Wallet;
+import org.hyperledger.fabric.gateway.X509Identity;
 import org.hyperledger.fabric.gateway.impl.identity.X509IdentityProvider;
 import org.hyperledger.fabric.gateway.spi.CommitHandlerFactory;
 import org.hyperledger.fabric.gateway.spi.QueryHandlerFactory;
@@ -112,6 +113,18 @@ public final class GatewayImpl implements Gateway {
             if (null == identity) {
                 throw new IllegalArgumentException("Identity not found in wallet: " + id);
             }
+            return this;
+        }
+
+        @Override
+        public Builder identity(final Identity identity) {
+            if (null == identity) {
+                throw new IllegalArgumentException("Identity must not be null");
+            }
+            if (!(identity instanceof X509Identity)) {
+                throw new IllegalArgumentException("No provider for identity type: " + identity.getClass().getName());
+            }
+            this.identity = identity;
             return this;
         }
 

--- a/src/test/java/scenario/ScenarioSteps.java
+++ b/src/test/java/scenario/ScenarioSteps.java
@@ -173,15 +173,17 @@ public class ScenarioSteps implements En {
 
         Given("I have a gateway as user {word} using the {word} connection profile",
                 (String userName, String tlsType) -> {
+                    prepareGateway(tlsType);
                     populateWallet();
-                    gatewayBuilder = Gateway.createBuilder();
                     gatewayBuilder.identity(wallet, userName);
-                    gatewayBuilder.networkConfig(getNetworkConfigPath(tlsType));
-                    gatewayBuilder.commitTimeout(1, TimeUnit.MINUTES);
-                    if (tlsType.equals("discovery")) {
-                        gatewayBuilder.discovery(true);
-                    }
                 });
+
+	    Given("I have a gateway with identity User1 using the {word} connection profile",
+	            (String tlsType) -> {
+                    prepareGateway(tlsType);
+                    Identity identity = newOrg1UserIdentity();
+                    gatewayBuilder.identity(identity);
+	            });
 
         Given("I configure the gateway to use the default {word} commit handler",
                 (String handlerName) -> gatewayBuilder.commitHandler(DefaultCommitHandlers.valueOf(handlerName)));
@@ -592,6 +594,15 @@ public class ScenarioSteps implements En {
     private void populateWallet() throws IOException, CertificateException, InvalidKeyException {
         Identity identity = newOrg1UserIdentity();
         wallet.put("User1", identity);
+    }
+
+    private void prepareGateway(String tlsType) throws IOException {
+        gatewayBuilder = Gateway.createBuilder();
+        gatewayBuilder.networkConfig(getNetworkConfigPath(tlsType));
+        gatewayBuilder.commitTimeout(1, TimeUnit.MINUTES);
+        if (tlsType.equals("discovery")) {
+            gatewayBuilder.discovery(true);
+        }
     }
 
     private static Identity newOrg1UserIdentity() throws IOException, CertificateException, InvalidKeyException {

--- a/src/test/resources/scenario/FabCar.feature
+++ b/src/test/resources/scenario/FabCar.feature
@@ -10,24 +10,44 @@ Feature: Configure Fabric using SDK and submit/evaluate using a network Gateway
 		And I deploy node chaincode named fabcar at version 1.0.0 for all organizations on channel mychannel with endorsement policy 1AdminOr2Other and arguments ["initLedger"]
 
  	Scenario: Using a Gateway I can submit and evaluate transactions on instantiated node chaincode
-		Given I have a gateway as user User1 using the tls connection profile
-		And I connect the gateway
-		And I use the mychannel network
-		And I use the fabcar contract
-		When I prepare a createCar transaction
-	 	And I submit the transaction with arguments ["CAR10", "Trabant", "601 Estate", "brown", "Simon"]
-		And I prepare a queryCar transaction
-	 	And I evaluate the transaction with arguments ["CAR10"]
-		Then the response should be JSON matching
-		    """
-		    {
-		    	"color": "brown",
-		    	"docType": "car",
-		    	"make": "Trabant",
-		    	"model": "601 Estate",
-		    	"owner": "Simon"
-		    }
-		    """
+        Given I have a gateway as user User1 using the tls connection profile
+        And I connect the gateway
+        And I use the mychannel network
+        And I use the fabcar contract
+        When I prepare a createCar transaction
+        And I submit the transaction with arguments ["CAR10", "Trabant", "601 Estate", "brown", "Simon"]
+        And I prepare a queryCar transaction
+        And I evaluate the transaction with arguments ["CAR10"]
+        Then the response should be JSON matching
+            """
+            {
+                "color": "brown",
+                "docType": "car",
+                "make": "Trabant",
+                "model": "601 Estate",
+                "owner": "Simon"
+            }
+            """
+
+    Scenario: Using a Gateway with an X509Identity I can submit and evaluate transactions on instantiated node chaincode
+        Given I have a gateway with identity User1 using the tls connection profile
+        And I connect the gateway
+        And I use the mychannel network
+        And I use the fabcar contract
+        When I prepare a createCar transaction
+        And I submit the transaction with arguments ["CAR11", "Tesla", "Model X", "black", "Jon Doe"]
+        And I prepare a queryCar transaction
+        And I evaluate the transaction with arguments ["CAR11"]
+        Then the response should be JSON matching
+            """
+            {
+                "color": "black",
+                "docType": "car",
+                "make": "Tesla",
+                "model": "Model X",
+                "owner": "Jon Doe"
+            }
+            """
 
 	Scenario: Using a Gateway I can submit transactions with specific endorsing peers
 		Given I have a gateway as user User1 using the tls connection profile


### PR DESCRIPTION
**Type of change:**

- New Feature

**Description:**

- This feature adds the ability to build a Gateway without using an identity stored in the Wallet.

- Gateway.Builder now has an overload of identity() method which supports this feature.

- Currently, only X509Identity is supported for this.

**JIRA Ticket**

- [FGJ-58](https://jira.hyperledger.org/browse/FGJ-58)