### PR TITLE
FGJ-87 Override version of commons-codec

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,11 @@
             <version>5.7.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency><!-- override the version under cloudant-client -->
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>1.14</version>
+        </dependency>
         <dependency>
             <groupId>com.cloudant</groupId>
             <artifactId>cloudant-client</artifactId>


### PR DESCRIPTION
cloudant-client has a dependency on commons-codec:1.6 which has a security alert.
This commit overrides this by adding an explicit dependency on the latest version.

Signed-off-by: andrew-coleman <andrew_coleman@uk.ibm.com>