### PR TITLE
[FABN-1271] Add "prefer MSP ID" strategies and change defaults (#340)

### DIFF
--- a/src/main/java/org/hyperledger/fabric/gateway/DefaultCommitHandlers.java
+++ b/src/main/java/org/hyperledger/fabric/gateway/DefaultCommitHandlers.java
@@ -49,6 +49,20 @@ public enum DefaultCommitHandlers implements CommitHandlerFactory {
     }),
 
     /**
+     * Wait to receive commit events from all currently responding peers in the user's organization after submitting
+     * a transaction. If the user's organization has no peers, then wait to receive commit events from all currently
+     * responding peers in the network instead.
+     */
+    PREFER_MSPID_SCOPE_ALLFORTX((transactionId, network) -> {
+        Collection<Peer> peers = getEventSourcePeersForOrganization(network);
+        if (peers.isEmpty()) {
+            peers = getEventSourcePeers(network);
+        }
+        CommitStrategy strategy = new AllCommitStrategy(peers);
+        return new CommitHandlerImpl(transactionId, network, strategy);
+    }),
+
+    /**
      * Wait to receive a commit event from any currently responding peer in the user's organization after submitting
      * a transaction.
      */
@@ -63,6 +77,20 @@ public enum DefaultCommitHandlers implements CommitHandlerFactory {
      */
     NETWORK_SCOPE_ANYFORTX((transactionId, network) -> {
         Collection<Peer> peers = getEventSourcePeers(network);
+        CommitStrategy strategy = new AnyCommitStrategy(peers);
+        return new CommitHandlerImpl(transactionId, network, strategy);
+    }),
+
+    /**
+     * Wait to receive a commit event from any currently responding peer in the user's organization after submitting
+     * a transaction. If the user's organization has no peers, then wait to receive a commit event from any currently
+     * responding peer in the network.
+     */
+    PREFER_MSPID_SCOPE_ANYFORTX((transactionId, network) -> {
+        Collection<Peer> peers = getEventSourcePeersForOrganization(network);
+        if (peers.isEmpty()) {
+            peers = getEventSourcePeers(network);
+        }
         CommitStrategy strategy = new AnyCommitStrategy(peers);
         return new CommitHandlerImpl(transactionId, network, strategy);
     });

--- a/src/main/java/org/hyperledger/fabric/gateway/DefaultQueryHandlers.java
+++ b/src/main/java/org/hyperledger/fabric/gateway/DefaultQueryHandlers.java
@@ -37,6 +37,32 @@ public enum DefaultQueryHandlers implements QueryHandlerFactory {
     MSPID_SCOPE_ROUND_ROBIN(network -> {
         Collection<Peer> peers = getChaincodeQueryPeersForOrganization(network);
         return new RoundRobinQueryHandler(peers);
+    }),
+
+    /**
+     * The last peer that provided a successful response is used. If a peer fails then all other peers will be tried
+     * in turn until one provides a successful response. If no peers respond then an exception is thrown. If the user's
+     * organization has no peers, then all peers in the network will be used.
+     */
+    PREFER_MSPID_SCOPE_SINGLE(network -> {
+        Collection<Peer> peers = getChaincodeQueryPeersForOrganization(network);
+        if (peers.isEmpty()) {
+            peers = getChaincodeQueryPeers(network);
+        }
+        return new SingleQueryHandler(peers);
+    }),
+
+    /**
+     * For each subsequent query, the next peer in the list is used. If a peer fails then all other peers will be tried
+     * in turn until one provides a successful response. If no peers respond then an exception is thrown. If the user's
+     * organization has no peers, then all peers in the network will be used.
+     */
+    PREFER_MSPID_SCOPE_ROUND_ROBIN(network -> {
+        Collection<Peer> peers = getChaincodeQueryPeersForOrganization(network);
+        if (peers.isEmpty()) {
+            peers = getChaincodeQueryPeers(network);
+        }
+        return new RoundRobinQueryHandler(peers);
     });
 
     private static final EnumSet<Peer.PeerRole> QUERY_ROLES = EnumSet.of(Peer.PeerRole.CHAINCODE_QUERY);

--- a/src/main/java/org/hyperledger/fabric/gateway/impl/GatewayImpl.java
+++ b/src/main/java/org/hyperledger/fabric/gateway/impl/GatewayImpl.java
@@ -64,9 +64,9 @@ public final class GatewayImpl implements Gateway {
     private final boolean discovery;
 
     public static final class Builder implements Gateway.Builder {
-        private CommitHandlerFactory commitHandlerFactory = DefaultCommitHandlers.MSPID_SCOPE_ALLFORTX;
+        private CommitHandlerFactory commitHandlerFactory = DefaultCommitHandlers.PREFER_MSPID_SCOPE_ALLFORTX;
         private TimePeriod commitTimeout = new TimePeriod(DEFAULT_COMMIT_TIMEOUT, DEFAULT_COMMIT_TIMEOUT_UNIT);
-        private QueryHandlerFactory queryHandlerFactory = DefaultQueryHandlers.MSPID_SCOPE_SINGLE;
+        private QueryHandlerFactory queryHandlerFactory = DefaultQueryHandlers.PREFER_MSPID_SCOPE_SINGLE;
         private NetworkConfig ccp = null;
         private Identity identity = null;
         private HFClient client;

--- a/src/test/fixtures/crypto-material/configtx.yaml
+++ b/src/test/fixtures/crypto-material/configtx.yaml
@@ -267,6 +267,36 @@ Organizations:
                 Type: Signature
                 Rule: "OR('Org2MSP.admin')"
 
+    - &Org3
+        # DefaultOrg defines the organization which is used in the sampleconfig
+        # of the fabric.git development environment
+        Name: Org3MSP
+
+        # ID to load the MSP definition as
+        ID: Org3MSP
+
+        MSPDir: crypto-config/peerOrganizations/org3.example.com/msp
+
+        # Policies defines the set of policies at this level of the config tree
+        # For organization policies, their canonical path is usually
+        #   /Channel/<Application|Orderer>/<OrgName>/<PolicyName>
+        Policies: &Org3Policies
+            Readers:
+                Type: Signature
+                Rule: "OR('Org3MSP.member')"
+                # If your MSP is configured with the new NodeOUs, you might
+                # want to use a more specific rule like the following:
+                # Rule: "OR('Org3MSP.admin', 'Org3MSP.peer', 'Org3MSP.client')"
+            Writers:
+                Type: Signature
+                Rule: "OR('Org3MSP.member')"
+                # If your MSP is configured with the new NodeOUs, you might
+                # want to use a more specific rule like the following:
+                # Rule: "OR('Org3MSP.admin', 'Org3MSP.client')"
+            Admins:
+                Type: Signature
+                Rule: "OR('Org3MSP.admin')"
+
 ################################################################################
 #
 #   Profile
@@ -277,7 +307,7 @@ Organizations:
 ################################################################################
 Profiles:
 
-    TwoOrgsOrdererGenesis:
+    ThreeOrgsOrdererGenesis:
         <<: *ChannelDefaults
         Orderer:
             <<: *OrdererDefaults
@@ -290,7 +320,8 @@ Profiles:
                 Organizations:
                     - *Org1
                     - *Org2
-    TwoOrgsChannel:
+                    - *Org3
+    ThreeOrgsChannel:
         <<: *ChannelDefaults
         Consortium: SampleConsortium
         Application:
@@ -298,5 +329,6 @@ Profiles:
             Organizations:
                 - *Org1
                 - *Org2
+                - *Org3
             Capabilities:
                 <<: *ApplicationCapabilities

--- a/src/test/fixtures/crypto-material/crypto-config.yaml
+++ b/src/test/fixtures/crypto-material/crypto-config.yaml
@@ -39,3 +39,12 @@ PeerOrgs:
       Count: 2
     Users:
       Count: 1
+  # ---------------------------------------------------------------------------
+  # Org3: See "Org1" for full specification
+  # ---------------------------------------------------------------------------
+  - Name: Org3
+    Domain: org3.example.com
+    Template:
+      Count: 0
+    Users:
+      Count: 1

--- a/src/test/fixtures/generate.sh
+++ b/src/test/fixtures/generate.sh
@@ -6,16 +6,16 @@ rm -f crypto-material/channel.tx
 rm -f crypto-material/core.yaml
 rm -f crypto-material/genesis.block
 rm -f crypto-material/mychannel.block
-rm -rf crypto-material/crypto-config  
+rm -rf crypto-material/crypto-config
 
 cd docker-compose
 
 docker-compose -f docker-compose-cli.yaml up -d
-docker exec cli cryptogen generate --config=/etc/hyperledger/config/crypto-config.yaml --output /etc/hyperledger/config/crypto-config
-docker exec cli configtxgen -profile TwoOrgsOrdererGenesis -outputBlock /etc/hyperledger/config/genesis.block -channelID testchainid
-docker exec cli configtxgen -profile TwoOrgsChannel -outputCreateChannelTx /etc/hyperledger/config/channel.tx -channelID mychannel
-docker exec cli configtxgen -profile TwoOrgsChannel -outputAnchorPeersUpdate /etc/hyperledger/config/Org1MSPanchors.tx -channelID mychannel -asOrg Org1MSP
-docker exec cli configtxgen -profile TwoOrgsChannel -outputAnchorPeersUpdate /etc/hyperledger/config/Org2MSPanchors.tx -channelID mychannel -asOrg Org2MSP
-docker exec cli cp /etc/hyperledger/fabric/core.yaml /etc/hyperledger/config
-docker exec cli sh /etc/hyperledger/config/rename_sk.sh
+docker exec -t cli cryptogen generate --config=/etc/hyperledger/config/crypto-config.yaml --output /etc/hyperledger/config/crypto-config
+docker exec -t cli configtxgen -profile ThreeOrgsOrdererGenesis -outputBlock /etc/hyperledger/config/genesis.block -channelID testchainid
+docker exec -t cli configtxgen -profile ThreeOrgsChannel -outputCreateChannelTx /etc/hyperledger/config/channel.tx -channelID mychannel
+docker exec -t cli configtxgen -profile ThreeOrgsChannel -outputAnchorPeersUpdate /etc/hyperledger/config/Org1MSPanchors.tx -channelID mychannel -asOrg Org1MSP
+docker exec -t cli configtxgen -profile ThreeOrgsChannel -outputAnchorPeersUpdate /etc/hyperledger/config/Org2MSPanchors.tx -channelID mychannel -asOrg Org2MSP
+docker exec -t cli cp /etc/hyperledger/fabric/core.yaml /etc/hyperledger/config
+docker exec -t cli sh /etc/hyperledger/config/rename_sk.sh
 docker-compose -f docker-compose-cli.yaml down --volumes

--- a/src/test/java/org/hyperledger/fabric/gateway/connection-client-only.json
+++ b/src/test/java/org/hyperledger/fabric/gateway/connection-client-only.json
@@ -1,0 +1,56 @@
+{
+	"name": "basic-network",
+	"version": "1.0.0",
+	"client": {
+		"organization": "Org3",
+		"connection": {
+			"timeout": {
+				"peer": {
+					"endorser": "300"
+				},
+				"orderer": "300"
+			}
+		}
+	},
+	"organizations": {
+		"Org3": {
+			"mspid": "Org3MSP",
+			"peers": [
+				"peer0.org1.example.com",
+				"peer0.org2.example.com"
+			],
+			"certificateAuthorities": [],
+			"adminPrivateKeyPEM": {
+				"path": "src/test/fixtures/crypto-material/crypto-config/peerOrganizations/org3.example.com/users/Admin@org3.example.com/msp/keystore/key.pem"
+			},
+			"signedCertPEM": {
+				"path": "src/test/fixtures/crypto-material/crypto-config/peerOrganizations/org3.example.com/users/Admin@org3.example.com/msp/signcerts/Admin@org3.example.com-cert.pem"
+			}
+		}
+	},
+	"peers": {
+		"peer0.org1.example.com": {
+			"url": "grpcs://localhost:7051",
+			"grpcOptions": {
+				"hostnameOverride": "peer0.org1.example.com",
+				"ssl-target-name-override": "peer0.org1.example.com",
+				"request-timeout": 120001
+			},
+			"tlsCACerts": {
+				"path": "src/test/fixtures/crypto-material/crypto-config/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/tls/ca.crt"
+			}
+		},
+		"peer0.org2.example.com": {
+			"url": "grpcs://localhost:8051",
+			"grpcOptions": {
+				"ssl-target-name-override": "peer0.org2.example.com",
+				"hostnameOverride": "peer0.org2.example.com",
+				"request-timeout": 120001
+			},
+			"tlsCACerts": {
+				"path": "src/test/fixtures/crypto-material/crypto-config/peerOrganizations/org2.example.com/peers/peer0.org2.example.com/tls/ca.crt"
+			}
+		}
+	},
+	"certificateAuthorities": {}
+}

--- a/src/test/java/scenario/ScenarioSteps.java
+++ b/src/test/java/scenario/ScenarioSteps.java
@@ -465,6 +465,8 @@ public class ScenarioSteps implements En {
                 return networkConfigDir.resolve("connection-discovery.json");
             case "basic":
                 return networkConfigDir.resolve("connection.json");
+            case "client-only":
+                return networkConfigDir.resolve("connection-client-only.json");
             default:
                 throw new IllegalArgumentException("Unknown network configuration type: " + configType);
         }

--- a/src/test/resources/scenario/client_only.feature
+++ b/src/test/resources/scenario/client_only.feature
@@ -1,0 +1,31 @@
+#
+# Copyright 2019 IBM All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+Feature: Configure Fabric using SDK using discovery service and submit/evaluate using a network Gateway for an organization that has no peers
+
+	Background:
+		Given I have deployed a tls Fabric network
+		And I have created and joined all channels from the tls connection profile
+		And I deploy node chaincode named marbles0 at version 1.0.0 for all organizations on channel mychannel with endorsement policy 1AdminOr2Other and arguments ["init", "a", "1000", "b", "2000"]
+
+ 	Scenario: Using a Gateway with discovery I can submit and evaluate transactions on instantiated node chaincode
+		Given I have a gateway as user User1 using the client-only connection profile
+		And I connect the gateway
+		And I use the mychannel network
+		And I use the marbles0 contract
+	 	When I prepare an initMarble transaction
+	 	And I submit the transaction with arguments ["marble2", "yellow", "25", "charlie"]
+	 	And I prepare a readMarble transaction
+	 	And I evaluate the transaction with arguments ["marble2"]
+	 	Then the response should be JSON matching
+		"""
+		{
+			"color":"yellow",
+			"docType":"marble",
+			"name":"marble2",
+			"owner":"charlie",
+			"size":25
+		}
+		"""


### PR DESCRIPTION
Add new event and query handler strategies of PREFER_MSPID_SCOPE
that use peers from the current organization if that organization
has any peers, otherwise fall back to peers from the network.

Set these strategies as the default strategy. This will allow us
to support client only organizations that do not have peers out
of the box, without needing to write custom handlers or change
to another strategy.

Signed-off-by: Simon Stone <sstone1@uk.ibm.com>