### PR TITLE
FGJ-109: Exclude all internal packages from Javadoc (release-2.2)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -237,7 +237,7 @@
                 <version>${javadoc.version}</version>
                 <configuration>
                     <excludePackageNames>
-                        org.hyperledger.fabric.gateway.impl
+                        org.hyperledger.fabric.gateway.impl:org.hyperledger.fabric.gateway.impl.*
                     </excludePackageNames>
                     <show>public</show>
                     <doctitle>Hyperledger Fabric Gateway SDK for Java</doctitle>
@@ -396,7 +396,7 @@
                         <version>${javadoc.version}</version>
                         <configuration>
                             <excludePackageNames>
-                                org.hyperledger.fabric.gateway.impl
+                                org.hyperledger.fabric.gateway.impl:org.hyperledger.fabric.gateway.impl.*
                             </excludePackageNames>
                             <show>public</show>
                             <doctitle>Hyperledger Fabric Gateway SDK for Java</doctitle>


### PR DESCRIPTION
Sub-packages of org.hyperledger.fabric.gateway.impl were not excluded.