### PR TITLE
Close InputStream on Wallet.get() (release-2.2)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,31 +56,31 @@
         <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-launcher</artifactId>
-            <version>1.6.2</version>
+            <version>1.8.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.6.2</version>
+            <version>5.8.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
-            <version>5.6.2</version>
+            <version>5.8.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.vintage</groupId>
             <artifactId>junit-vintage-engine</artifactId>
-            <version>5.6.2</version>
+            <version>5.8.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.16.1</version>
+            <version>3.22.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -91,30 +91,30 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>3.3.3</version>
+            <version>4.3.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.cucumber</groupId>
             <artifactId>cucumber-java8</artifactId>
-            <version>5.7.0</version>
+            <version>7.2.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.cucumber</groupId>
             <artifactId>cucumber-junit</artifactId>
-            <version>5.7.0</version>
+            <version>7.2.3</version>
             <scope>test</scope>
         </dependency>
         <dependency><!-- override the version under cloudant-client -->
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.14</version>
+            <version>1.15</version>
         </dependency>
         <dependency>
             <groupId>com.ibm.cloud</groupId>
             <artifactId>cloudant</artifactId>
-            <version>0.0.32</version>
+            <version>0.0.34</version>
         </dependency>
     </dependencies>
 
@@ -263,7 +263,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>3.1.2</version>
                 <configuration>
                     <configLocation>checkstyle.xml</configLocation>
                     <encoding>UTF-8</encoding>
@@ -276,7 +276,7 @@
                     <dependency>
                         <groupId>com.puppycrawl.tools</groupId>
                         <artifactId>checkstyle</artifactId>
-                        <version>8.30</version>
+                        <version>9.3</version>
                     </dependency>
                 </dependencies>
                 <executions>

--- a/src/main/java/org/hyperledger/fabric/gateway/impl/identity/WalletImpl.java
+++ b/src/main/java/org/hyperledger/fabric/gateway/impl/identity/WalletImpl.java
@@ -64,15 +64,16 @@ public final class WalletImpl implements Wallet {
 
     @Override
     public Identity get(final String label) throws IOException {
-        final InputStream identityData = store.get(label);
-        if (identityData == null) {
-            return null;
-        }
+        try (InputStream identityData = store.get(label)) {
+            if (identityData == null) {
+                return null;
+            }
 
-        try {
-            return deserializeIdentity(identityData);
-        } catch (RuntimeException e) {
-            throw new IOException(e);
+            try {
+                return deserializeIdentity(identityData);
+            } catch (RuntimeException e) {
+                throw new IOException(e);
+            }
         }
     }
 

--- a/src/test/java/org/hyperledger/fabric/gateway/impl/TransactionTest.java
+++ b/src/test/java/org/hyperledger/fabric/gateway/impl/TransactionTest.java
@@ -17,7 +17,6 @@ import java.util.concurrent.TimeUnit;
 
 import org.hyperledger.fabric.gateway.Contract;
 import org.hyperledger.fabric.gateway.ContractException;
-import org.hyperledger.fabric.gateway.DefaultCommitHandlers;
 import org.hyperledger.fabric.gateway.Gateway;
 import org.hyperledger.fabric.gateway.GatewayException;
 import org.hyperledger.fabric.gateway.Network;
@@ -29,17 +28,16 @@ import org.hyperledger.fabric.sdk.Channel;
 import org.hyperledger.fabric.sdk.HFClient;
 import org.hyperledger.fabric.sdk.Peer;
 import org.hyperledger.fabric.sdk.ProposalResponse;
-import org.hyperledger.fabric.sdk.QueryByChaincodeRequest;
 import org.hyperledger.fabric.sdk.TransactionProposalRequest;
-import org.hyperledger.fabric.sdk.TransactionRequest;
-import org.hyperledger.fabric.sdk.User;
 import org.hyperledger.fabric.sdk.transaction.TransactionContext;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
-import org.mockito.MockitoAnnotations;
+import org.mockito.Mockito;
+import org.mockito.MockitoSession;
+import org.mockito.quality.Strictness;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -57,6 +55,7 @@ import static org.mockito.Mockito.when;
 public class TransactionTest {
     private final TestUtils testUtils = TestUtils.getInstance();
     private final TimePeriod timeout = new TimePeriod(7, TimeUnit.DAYS);
+    private MockitoSession mockitoSession;
     private Gateway.Builder gatewayBuilder;
     private Gateway gateway;
     private Channel channel;
@@ -79,7 +78,10 @@ public class TransactionTest {
 
     @BeforeEach
     public void setup() throws Exception {
-        MockitoAnnotations.initMocks(this);
+        mockitoSession = Mockito.mockitoSession()
+                .initMocks(this)
+                .strictness(Strictness.LENIENT)
+                .startMocking();
 
         peer1 = testUtils.newMockPeer("peer1");
         peer2 = testUtils.newMockPeer("peer2");
@@ -117,6 +119,7 @@ public class TransactionTest {
     @AfterEach
     public void afterEach() {
         gateway.close();
+        mockitoSession.finishMocking();
     }
 
     @Test

--- a/src/test/java/scenario/RunScenarioTest.java
+++ b/src/test/java/scenario/RunScenarioTest.java
@@ -6,6 +6,6 @@ import io.cucumber.junit.Cucumber;
 import io.cucumber.junit.CucumberOptions;
 
 @RunWith(Cucumber.class)
-@CucumberOptions(plugin = {"pretty"}, strict = true)
+@CucumberOptions(plugin = {"pretty"})
 public class RunScenarioTest {
 }


### PR DESCRIPTION
Cherry-pick of e50a619ada02d5434c3fbfae539f123e509fa8e9 from main branch.

The Wallet get() method did not close the InputStream returned by the WalletStore. For store implementations backed by persistent storage, such as FileSystemWalletStore, this was a resource leak.

Updated dependency versions.