### PR TITLE
Fix Javadoc build for Java 17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <javaVersion>8</javaVersion>
-        <javadoc.version>3.2.0</javadoc.version>
+        <javadoc.version>3.3.2</javadoc.version>
     </properties>
 
     <repositories>
@@ -158,7 +158,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.0.0-M4</version>
+                    <version>3.0.0-M5</version>
                     <configuration>
                         <excludes>
                             <exclude>**/scenario/**</exclude>
@@ -314,7 +314,7 @@
                     <plugin>
                         <groupId>org.owasp</groupId>
                         <artifactId>dependency-check-maven</artifactId>
-                        <version>6.5.2</version>
+                        <version>6.5.3</version>
                         <configuration>
                             <skipProvidedScope>true</skipProvidedScope>
                             <skipTestScope>true</skipTestScope>
@@ -335,7 +335,7 @@
         <profile>
             <id>javadoc-no-module-directories</id>
             <activation>
-                <jdk>[11,)</jdk>
+                <jdk>[11,13)</jdk>
             </activation>
             <properties>
                 <additionalJavadocOpts>--no-module-directories</additionalJavadocOpts>


### PR DESCRIPTION
Even if the path and compiler target point to a different Java version, the Java version associated with the Maven CLI can cause Javadodc build failures in systems with Java 17 installed. Set an upper bound (in addition to the lower bound) for the build profile that enables the `--no-module-directories` Javadoc option.