### PR TITLE
Dependency vulnerability scan in nightly build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -70,6 +70,9 @@ stages:
             Java11:
               versionSpec: '1.11'
               sslProvider: 'JDK'
+            Java17:
+              versionSpec: '17'
+              sslProvider: 'JDK'
         steps:
           - task: Maven@3
             displayName: Maven build and run tests
@@ -109,3 +112,23 @@ stages:
               PROJECT_DIR: "$(Build.Repository.LocalPath)"
               STAGING_DIR: "$(Build.StagingDirectory)/gh-pages"
               SOURCE_BRANCH: "$(Build.SourceBranchName)"
+
+  # Only run security vulnerability scan on scheduled builds
+  - stage: Scan
+    dependsOn: []
+    condition: eq(variables['Build.Reason'], 'Schedule')
+    jobs:
+      - job: ScanDependencies
+        pool:
+          vmImage: ubuntu-20.04
+        dependsOn: []
+        timeoutInMinutes: 60
+        steps:
+          - task: Maven@3
+            displayName: 'Maven dependency-check'
+            inputs:
+              mavenPomFile: 'pom.xml'
+              goals: '-P owasp dependency-check:check'
+          - publish: $(System.DefaultWorkingDirectory)/target/dependency-check-report.html
+            artifact: DependencyCheck
+            displayName: 'Upload dependency-check report'

--- a/dependency-suppressions.xml
+++ b/dependency-suppressions.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2022 IBM All Rights Reserved.
+  ~
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+    <suppress>
+        <notes><![CDATA[
+        CVE was reported against @grpc/grpc-js npm package, not Java
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.opentelemetry\.instrumentation/opentelemetry\-grpc\-1\.6@.*$</packageUrl>
+        <cve>CVE-2020-7768</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+        CVE was reported in version 1.4-M1 to 1.4-RC and fixed in version 1.4.0
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.jetbrains\.kotlin/kotlin\-stdlib\-common@1\.4\.0$</packageUrl>
+        <cve>CVE-2020-15824</cve>
+    </suppress>
+</suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>4.3.1</version>
+            <version>4.4.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -114,7 +114,7 @@
         <dependency>
             <groupId>com.ibm.cloud</groupId>
             <artifactId>cloudant</artifactId>
-            <version>0.0.34</version>
+            <version>0.0.36</version>
         </dependency>
     </dependencies>
 
@@ -260,35 +260,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>3.1.2</version>
-                <configuration>
-                    <configLocation>checkstyle.xml</configLocation>
-                    <encoding>UTF-8</encoding>
-                    <consoleOutput>true</consoleOutput>
-                    <failsOnError>true</failsOnError>
-                    <linkXRef>false</linkXRef>
-                    <propertyExpansion>basedir=${project.basedir}</propertyExpansion>
-                </configuration>
-                <dependencies>
-                    <dependency>
-                        <groupId>com.puppycrawl.tools</groupId>
-                        <artifactId>checkstyle</artifactId>
-                        <version>9.3</version>
-                    </dependency>
-                </dependencies>
-                <executions>
-                    <execution>
-                        <id>compile</id>
-                        <phase>compile</phase>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 
@@ -308,18 +279,60 @@
     </distributionManagement>
     <profiles>
         <profile>
+            <id>checkstyle</id>
+            <activation>
+                <jdk>[11,)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-checkstyle-plugin</artifactId>
+                        <version>3.1.2</version>
+                        <configuration>
+                            <configLocation>checkstyle.xml</configLocation>
+                            <encoding>UTF-8</encoding>
+                            <consoleOutput>true</consoleOutput>
+                            <failsOnError>true</failsOnError>
+                            <linkXRef>false</linkXRef>
+                            <propertyExpansion>basedir=${project.basedir}</propertyExpansion>
+                        </configuration>
+                        <dependencies>
+                            <dependency>
+                                <groupId>com.puppycrawl.tools</groupId>
+                                <artifactId>checkstyle</artifactId>
+                                <version>10.0</version>
+                            </dependency>
+                        </dependencies>
+                        <executions>
+                            <execution>
+                                <id>compile</id>
+                                <phase>compile</phase>
+                                <goals>
+                                    <goal>check</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
             <id>owasp</id>
             <build>
                 <plugins>
                     <plugin>
                         <groupId>org.owasp</groupId>
                         <artifactId>dependency-check-maven</artifactId>
-                        <version>6.5.3</version>
+                        <version>7.0.1</version>
                         <configuration>
                             <skipProvidedScope>true</skipProvidedScope>
                             <skipTestScope>true</skipTestScope>
                             <skipSystemScope>true</skipSystemScope>
                             <failBuildOnCVSS>7</failBuildOnCVSS>
+                            <suppressionFiles>
+                                <suppressionFile>dependency-suppressions.xml</suppressionFile>
+                            </suppressionFiles>
                         </configuration>
                         <executions>
                             <execution>


### PR DESCRIPTION
- Update dependencies to latest versions.
- Required Java 11+ to run checkstyle as v10 is not compatible with earlier Java versions.
- Add testing with Java 17.