### PR TITLE
Remove scheduled vulnerability scan for Azure Pipelines build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -112,23 +112,3 @@ stages:
               PROJECT_DIR: "$(Build.Repository.LocalPath)"
               STAGING_DIR: "$(Build.StagingDirectory)/gh-pages"
               SOURCE_BRANCH: "$(Build.SourceBranchName)"
-
-  # Only run security vulnerability scan on scheduled builds
-  - stage: Scan
-    dependsOn: []
-    condition: eq(variables['Build.Reason'], 'Schedule')
-    jobs:
-      - job: ScanDependencies
-        pool:
-          vmImage: ubuntu-20.04
-        dependsOn: []
-        timeoutInMinutes: 60
-        steps:
-          - task: Maven@3
-            displayName: 'Maven dependency-check'
-            inputs:
-              mavenPomFile: 'pom.xml'
-              goals: '-P owasp dependency-check:check'
-          - publish: $(System.DefaultWorkingDirectory)/target/dependency-check-report.html
-            artifact: DependencyCheck
-            displayName: 'Upload dependency-check report'

--- a/pom.xml
+++ b/pom.xml
@@ -324,7 +324,7 @@
                     <plugin>
                         <groupId>org.owasp</groupId>
                         <artifactId>dependency-check-maven</artifactId>
-                        <version>7.1.0</version>
+                        <version>7.1.1</version>
                         <configuration>
                             <skipProvidedScope>true</skipProvidedScope>
                             <skipTestScope>true</skipTestScope>


### PR DESCRIPTION
Vulnerability scans are now driven by a scheduled GitHub Actions workflow in the main branch. See PR #111.