### PR TITLE
Use correct CryptoSuite and User context for event replay

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,31 +56,31 @@
         <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-launcher</artifactId>
-            <version>1.8.2</version>
+            <version>1.9.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.8.2</version>
+            <version>5.9.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
-            <version>5.8.2</version>
+            <version>5.9.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.vintage</groupId>
             <artifactId>junit-vintage-engine</artifactId>
-            <version>5.8.2</version>
+            <version>5.9.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.22.0</version>
+            <version>3.23.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -91,19 +91,19 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>4.4.0</version>
+            <version>4.8.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.cucumber</groupId>
             <artifactId>cucumber-java8</artifactId>
-            <version>7.2.3</version>
+            <version>7.7.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.cucumber</groupId>
             <artifactId>cucumber-junit</artifactId>
-            <version>7.2.3</version>
+            <version>7.7.0</version>
             <scope>test</scope>
         </dependency>
         <dependency><!-- override the version under cloudant-client -->
@@ -114,7 +114,7 @@
         <dependency>
             <groupId>com.ibm.cloud</groupId>
             <artifactId>cloudant</artifactId>
-            <version>0.1.4</version>
+            <version>0.3.0</version>
         </dependency>
     </dependencies>
 
@@ -288,7 +288,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-checkstyle-plugin</artifactId>
-                        <version>3.1.2</version>
+                        <version>3.2.0</version>
                         <configuration>
                             <configLocation>checkstyle.xml</configLocation>
                             <encoding>UTF-8</encoding>
@@ -301,7 +301,7 @@
                             <dependency>
                                 <groupId>com.puppycrawl.tools</groupId>
                                 <artifactId>checkstyle</artifactId>
-                                <version>10.0</version>
+                                <version>10.3.3</version>
                             </dependency>
                         </dependencies>
                         <executions>
@@ -324,7 +324,7 @@
                     <plugin>
                         <groupId>org.owasp</groupId>
                         <artifactId>dependency-check-maven</artifactId>
-                        <version>7.1.1</version>
+                        <version>7.2.0</version>
                         <configuration>
                             <skipProvidedScope>true</skipProvidedScope>
                             <skipTestScope>true</skipTestScope>

--- a/src/main/java/org/hyperledger/fabric/gateway/ContractException.java
+++ b/src/main/java/org/hyperledger/fabric/gateway/ContractException.java
@@ -18,7 +18,7 @@ import org.hyperledger.fabric.sdk.ProposalResponse;
 public class ContractException extends GatewayException {
     private static final long serialVersionUID = -1278679656087547825L;
 
-    private Collection<ProposalResponse> proposalResponses;
+    private transient Collection<ProposalResponse> proposalResponses = Collections.emptyList();
 
     /**
      * Constructs a new exception with the specified detail message. The cause and payload are not initialized.
@@ -26,7 +26,6 @@ public class ContractException extends GatewayException {
      */
     public ContractException(final String message) {
         super(message);
-        this.proposalResponses = Collections.emptyList();
     }
 
     /**
@@ -36,7 +35,6 @@ public class ContractException extends GatewayException {
      */
     public ContractException(final String message, final Throwable cause) {
         super(message, cause);
-        this.proposalResponses = Collections.emptyList();
     }
 
     /**


### PR DESCRIPTION
Use the exact CryptoSuite and User context from the original HFClient when creating a new HFClient for event replay, instead of assuming that the CryptoSuite and User context are ones created using an X509IdentityProvider with the Gateway client identity.

Also updates dependency versions and fixed a compile warning in ContractException that could appear with Java 17.

Closes #117