### PR TITLE
Add the ability to config HFClient executorService through Gateway to Solve OutOfMemoryError

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
         <dependency>
             <groupId>org.hyperledger.fabric-sdk-java</groupId>
             <artifactId>fabric-sdk-java</artifactId>
-            <version>[2.2.0,2.3.0)</version>
+            <version>[2.2.19,2.3.0)</version>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/src/main/java/org/hyperledger/fabric/gateway/Gateway.java
+++ b/src/main/java/org/hyperledger/fabric/gateway/Gateway.java
@@ -9,12 +9,12 @@ package org.hyperledger.fabric.gateway;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import org.hyperledger.fabric.gateway.impl.GatewayImpl;
 import org.hyperledger.fabric.gateway.spi.CommitHandlerFactory;
 import org.hyperledger.fabric.gateway.spi.QueryHandlerFactory;
+import org.hyperledger.fabric.sdk.HFClient;
 
 /**
  * The Gateway provides the connection point for an application to access the Fabric network as a specific user. It is
@@ -87,6 +87,13 @@ public interface Gateway extends AutoCloseable {
     static Builder createBuilder() {
         return new GatewayImpl.Builder();
     }
+
+    /**
+     * Get the Client used by the gateway connection.
+     *
+     * @return The Client used by this Gateway.
+     */
+    HFClient getClient();
 
     /**
      * Close the gateway connection and all associated resources, including removing listeners attached to networks and
@@ -175,13 +182,6 @@ public interface Gateway extends AutoCloseable {
          * @return The builder instance, allowing multiple configuration options to be chained.
          */
         Builder discovery(boolean enabled);
-
-        /**
-         * <em>Optional</em> - Set executor service for gateway client.
-         * @param executorService - The executor service the application wants to use.
-         * @return The builder instance, allowing multiple configuration options to be chained.
-         */
-        Builder executorService(ExecutorService executorService);
 
         /**
          * Connects to the gateway using the specified options.

--- a/src/main/java/org/hyperledger/fabric/gateway/Gateway.java
+++ b/src/main/java/org/hyperledger/fabric/gateway/Gateway.java
@@ -9,6 +9,7 @@ package org.hyperledger.fabric.gateway;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import org.hyperledger.fabric.gateway.impl.GatewayImpl;
@@ -174,6 +175,13 @@ public interface Gateway extends AutoCloseable {
          * @return The builder instance, allowing multiple configuration options to be chained.
          */
         Builder discovery(boolean enabled);
+
+        /**
+         * <em>Optional</em> - Set executor service for gateway client.
+         * @param executorService - The executor service the application wants to use.
+         * @return The builder instance, allowing multiple configuration options to be chained.
+         */
+        Builder executorService(ExecutorService executorService);
 
         /**
          * Connects to the gateway using the specified options.

--- a/src/main/java/org/hyperledger/fabric/gateway/impl/GatewayImpl.java
+++ b/src/main/java/org/hyperledger/fabric/gateway/impl/GatewayImpl.java
@@ -46,7 +46,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
 public final class GatewayImpl implements Gateway {
@@ -56,7 +55,6 @@ public final class GatewayImpl implements Gateway {
     private static final TimeUnit DEFAULT_COMMIT_TIMEOUT_UNIT = TimeUnit.MINUTES;
 
     private final HFClient client;
-    private final ExecutorService executorService;
     private final NetworkConfig networkConfig;
     private final Identity identity;
     private final Map<String, NetworkImpl> networks = new HashMap<>();
@@ -72,7 +70,6 @@ public final class GatewayImpl implements Gateway {
         private NetworkConfig ccp = null;
         private Identity identity = null;
         private HFClient client;
-        private ExecutorService executorService;
         private boolean discovery = false;
 
         private static final class ExposedByteArrayOutputStream extends ByteArrayOutputStream {
@@ -161,12 +158,6 @@ public final class GatewayImpl implements Gateway {
         }
 
         @Override
-        public Builder executorService(final ExecutorService executorService) {
-            this.executorService = executorService;
-            return this;
-        }
-
-        @Override
         public GatewayImpl connect() {
             return new GatewayImpl(this);
         }
@@ -177,7 +168,6 @@ public final class GatewayImpl implements Gateway {
         this.commitTimeout = builder.commitTimeout;
         this.queryHandlerFactory = builder.queryHandlerFactory;
         this.discovery = builder.discovery;
-        this.executorService = builder.executorService;
 
         if (builder.client != null) {
             // Only for testing!
@@ -204,14 +194,6 @@ public final class GatewayImpl implements Gateway {
             // Hard-coded type for now but needs to get appropriate provider from wallet (or registry)
             X509IdentityProvider.INSTANCE.setUserContext(client, identity, "gateway");
         }
-
-        if (builder.executorService != null) {
-            try {
-                this.client.setExecutorService(builder.executorService);
-            } catch (InvalidArgumentException e) {
-                throw new GatewayRuntimeException(e);
-            }
-        }
     }
 
     private GatewayImpl(final GatewayImpl that) {
@@ -221,15 +203,12 @@ public final class GatewayImpl implements Gateway {
         this.discovery = that.discovery;
         this.networkConfig = that.networkConfig;
         this.identity = that.identity;
-        this.executorService = that.executorService;
 
         this.client = HFClient.createNewInstance();
         try {
             client.setCryptoSuite(that.client.getCryptoSuite());
             client.setUserContext(that.client.getUserContext());
-            if (that.executorService != null) {
-                client.setExecutorService(that.executorService);
-            }
+            client.setExecutorService(that.client.getExecutorService());
         } catch (CryptoException | InvalidArgumentException e) {
             throw new RuntimeException(e);
         }

--- a/src/test/java/org/hyperledger/fabric/gateway/impl/GatewayTest.java
+++ b/src/test/java/org/hyperledger/fabric/gateway/impl/GatewayTest.java
@@ -107,4 +107,13 @@ public class GatewayTest {
             assertThat(copy.getClient().getUserContext()).isSameAs(gateway.getClient().getUserContext());
         }
     }
+
+    @Test
+    public void testNewInstanceHasSameExecutorService() {
+        try (GatewayImpl gateway = builder.connect()) {
+            GatewayImpl copy = gateway.newInstance();
+
+            assertThat(copy.getClient().getExecutorService()).isSameAs(gateway.getClient().getExecutorService());
+        }
+    }
 }


### PR DESCRIPTION
when receiving event block, Channel class call 
`HFClient.getExecutorService.execute(() -> l.listener.received(blockEvent))`

If HFClient executorService is not set, HFClient use the default executorService which is [ThreadPoolExecutor](https://docs.oracle.com/javase/8/docs/api/index.html) with **Direct handoffs strategy** for queuing that strategy hands off tasks to threads without otherwise holding them. it's create new native Thread to run task if if no threads are available to run it.

HFClient default executerServise(ThreadPoolExecutor) has the following properties:
- corePoolSize = 0
- maximumPoolSize = Integer.Max(2147483647)
- keepAliveTime = 60
- timeUnit = SECONDS
- workQueue = SynchronousQueue (that hands off tasks to threads without otherwise holding them. 
		an attempt to queue a task will fail if no threads are immediately available to run it(require unbounded maximumPoolSizes to avoid rejection of new submitted tasks), so a new thread will be constructed)
- threadFactory = create new thread using Executors.defaultThreadFactory()


If the program receives a huge number of block events at the same time,it creates new **native Thread which is expensive resource** for every task to handle block event. this maybe cause 
```
java.lang.OutOfMemoryError: unable to create new native thread
	at java.lang.Thread.start0(Native Method)
	at java.lang.Thread.start(Thread.java:717)
	at java.util.concurrent.ThreadPoolExecutor.addWorker(ThreadPoolExecutor.java:957)
	at java.util.concurrent.ThreadPoolExecutor.execute(ThreadPoolExecutor.java:1378)
	at org.hyperledger.fabric.sdk.Channel.lambda$startEventQue$13(Channel.java:5954)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```
depend on machine resouces. 

so we need way to custmize HFClient executerServise through Gateway.Builder, 
The new method:
`Builder clientExecutor(ExecutorService executorService);` 
was added to Gateway.Builder to give the freedom to the library user to use another executerServise with anothor queuing strategies 
like **Unbounded queues Strategy** or Bounded queues strategy to **actually enqueue Tasks**.

### How to use
```
ThreadPoolExecutor executor = new ThreadPoolExecutor(corePoolSize, maximumPoolSize,
				0, TimeUnit.MILLISECONDS, new LinkedBlockingQueue<>(),
				r -> {
					Thread thread = defaultThreadFactory().newThread(r);
					thread.setDaemon(true);
					return thread;
				});
Builder builder = Gateway.createBuilder();
builder.identity(wallet, orgMSPName).networkConfig(networkConfigPath).discovery(true)
	.executorService(executor).commitHandler(DefaultCommitHandlers.NONE);
gateway = builder.connect();
```

with the added changes and the executorService above with **Unbounded queues Strategy**, Program was able hadle Tens of thousands of block events received at the same time steadily withot facing annoying OutOfMemoryError and without need to upgrade machines. because **storing tasks in Queue consumes mush less memory than creating native Threads**. in addition to avoid Context Switching.

closes #84 
may also ratated to issue #106 