### PR TITLE
Update Java dependency-check version

### DIFF
--- a/dependency-suppressions.xml
+++ b/dependency-suppressions.xml
@@ -15,8 +15,8 @@
     </suppress>
     <suppress>
         <notes><![CDATA[
-       Vulnerability in core Fabric Go implementation, not the Java SDK
-       ]]></notes>
+        Vulnerability in core Fabric Go implementation, not the Java SDK
+        ]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.hyperledger\.fabric\-sdk\-java/fabric\-sdk\-java@.*$</packageUrl>
         <cve>CVE-2022-36023</cve>
     </suppress>
@@ -26,5 +26,19 @@
         ]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.yaml/snakeyaml@.*$</packageUrl>
         <vulnerabilityName>CVE-2022-1471</vulnerabilityName>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+        Vulnerability in gopkg.in/yaml.v3 Golang module, not SnakeYaml
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.yaml/snakeyaml@.*$</packageUrl>
+        <cve>CVE-2022-3064</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+        Vulnerability in gopkg.in/yaml.v3 Golang module, not SnakeYaml
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.yaml/snakeyaml@.*$</packageUrl>
+        <cve>CVE-2021-4235</cve>
     </suppress>
 </suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -337,7 +337,7 @@
                     <plugin>
                         <groupId>org.owasp</groupId>
                         <artifactId>dependency-check-maven</artifactId>
-                        <version>7.3.2</version>
+                        <version>7.4.4</version>
                         <configuration>
                             <skipProvidedScope>true</skipProvidedScope>
                             <skipTestScope>true</skipTestScope>


### PR DESCRIPTION
Resolves an issue that prevented dependency-check running due to long CVE content.

Also suppress two false positives for SnakeYaml triggered by go-yaml CVEs.