### PR TITLE
Simplify pull request checks

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -12,3 +12,10 @@ concurrency:
 jobs:
   build:
     uses: ./.github/workflows/test.yml
+
+  pull-request:
+    needs: build
+    name: Pull request success
+    runs-on: ubuntu-latest
+    steps:
+      - run: true


### PR DESCRIPTION
Add a job to the end of the pull_request workflow that depends on the build jobs, and can be used as a single job to check pull request success. This avoids the need to change the branch protection PR checks when changes are made to the build process.