### PR TITLE
Fix release publishing to GitHub packages

### DIFF
--- a/.github/scripts/maven_publish_release.sh
+++ b/.github/scripts/maven_publish_release.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+PUBLISH_PROFILE="${1:?}"
+
+POM_VERSION=$(mvn org.apache.maven.plugins:maven-help-plugin:evaluate -Dexpression=project.version -q -DforceStdout)
+PUBLISH_VERSION="${POM_VERSION%%-*}"
+
+mvn --batch-mode --no-transfer-progress versions:set -DnewVersion="${PUBLISH_VERSION}"
+mvn --batch-mode --no-transfer-progress --activate-profiles "release,${PUBLISH_PROFILE}" -DskipTests deploy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,16 +22,10 @@ jobs:
           gpg-private-key: ${{ secrets.OSSRH_GPG_SECRET_KEY }}
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
       - name: Publish
-        shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }}
-          PUBLISH_PROFILE: github
-        run: |
-          POM_VERSION=$(mvn org.apache.maven.plugins:maven-help-plugin:evaluate -Dexpression=project.version -q -DforceStdout)
-          PUBLISH_VERSION="${POM_VERSION%%-*}"
-          mvn --batch-mode --no-transfer-progress versions:set -DnewVersion="${PUBLISH_VERSION}"
-          mvn --batch-mode --no-transfer-progress --activate-profiles "release,${PUBLISH_PROFILE}" -DskipTests deploy
+        run: ${{ github.workspace }}/.github/scripts/maven_publish_release.sh github
 
   publish-ossrh:
     name: Publish Java artifact to Maven Central
@@ -49,14 +43,8 @@ jobs:
           gpg-private-key: ${{ secrets.OSSRH_GPG_SECRET_KEY }}
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
       - name: Publish
-        shell: bash
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }}
-          PUBLISH_PROFILE: ossrh
-        run: |
-          POM_VERSION=$(mvn org.apache.maven.plugins:maven-help-plugin:evaluate -Dexpression=project.version -q -DforceStdout)
-          PUBLISH_VERSION="${POM_VERSION%%-*}"
-          mvn --batch-mode --no-transfer-progress versions:set -DnewVersion="${PUBLISH_VERSION}"
-          mvn --batch-mode --no-transfer-progress --activate-profiles "release,${PUBLISH_PROFILE}" -DskipTests deploy
+        run: ${{ github.workspace }}/.github/scripts/maven_publish_release.sh ossrh

--- a/pom.xml
+++ b/pom.xml
@@ -46,14 +46,14 @@
             <dependency>
                 <groupId>io.cucumber</groupId>
                 <artifactId>cucumber-bom</artifactId>
-                <version>7.10.0</version>
+                <version>7.11.2</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.junit</groupId>
                 <artifactId>junit-bom</artifactId>
-                <version>5.9.1</version>
+                <version>5.9.2</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -84,7 +84,7 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.23.1</version>
+            <version>3.24.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -95,7 +95,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>4.9.0</version>
+            <version>4.11.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>com.ibm.cloud</groupId>
             <artifactId>cloudant</artifactId>
-            <version>0.4.1</version>
+            <version>0.5.0</version>
         </dependency>
     </dependencies>
 
@@ -318,7 +318,7 @@
                             <dependency>
                                 <groupId>com.puppycrawl.tools</groupId>
                                 <artifactId>checkstyle</artifactId>
-                                <version>10.5.0</version>
+                                <version>10.9.3</version>
                             </dependency>
                         </dependencies>
                         <executions>
@@ -341,7 +341,7 @@
                     <plugin>
                         <groupId>org.owasp</groupId>
                         <artifactId>dependency-check-maven</artifactId>
-                        <version>8.1.2</version>
+                        <version>8.2.1</version>
                         <configuration>
                             <skipProvidedScope>true</skipProvidedScope>
                             <skipTestScope>true</skipTestScope>
@@ -377,7 +377,7 @@
                 <plugins>
                     <plugin>
                         <artifactId>maven-assembly-plugin</artifactId>
-                        <version>3.4.2</version>
+                        <version>3.5.0</version>
                         <configuration>
                             <descriptorRefs>
                                 <descriptorRef>jar-with-dependencies</descriptorRef>
@@ -421,7 +421,7 @@
                 <repository>
                     <id>github</id>
                     <name>GitHub Packages</name>
-                    <url>https://maven.pkg.github.com/hyperledger/fabric-gateway</url>
+                    <url>https://maven.pkg.github.com/hyperledger/fabric-gateway-java</url>
                 </repository>
             </distributionManagement>
         </profile>


### PR DESCRIPTION
Repository URL was incorrect, making release publishing fail.

Refactored release workflow to extract shell scripting common between GitHub and Maven Central publish to a shellscript invoked by both jobs.

Updated a few dependency versions.