### PR TITLE
Define NVD_API_KEY in vulnerability scan

### DIFF
--- a/.github/workflows/vulnerability-scan.yml
+++ b/.github/workflows/vulnerability-scan.yml
@@ -16,6 +16,8 @@ jobs:
           distribution: "temurin"
           cache: maven
       - name: Scan
+        env:
+          NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
         run: mvn -P owasp dependency-check:check
       - name: "Archive dependency-check report"
         if: success() || failure()

--- a/dependency-suppressions.xml
+++ b/dependency-suppressions.xml
@@ -8,24 +8,10 @@
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
     <suppress>
         <notes><![CDATA[
-        CVE was reported against @grpc/grpc-js npm package, not Java
-        ]]></notes>
-        <packageUrl regex="true">^pkg:maven/io\.opentelemetry\.instrumentation/opentelemetry\-grpc\-1\.6@.*$</packageUrl>
-        <cve>CVE-2020-7768</cve>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[
         Vulnerability in core Fabric Go implementation, not the Java SDK
         ]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.hyperledger\.fabric\-sdk\-java/fabric\-sdk\-java@.*$</packageUrl>
         <cve>CVE-2022-36023</cve>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[
-        fabric-sdk-java only uses SnakeYaml's SafeConstructor for parsing YAML, which mitigates the vulnerability
-        ]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.yaml/snakeyaml@.*$</packageUrl>
-        <vulnerabilityName>CVE-2022-1471</vulnerabilityName>
     </suppress>
     <suppress>
         <notes><![CDATA[

--- a/pom.xml
+++ b/pom.xml
@@ -359,7 +359,7 @@
                     <plugin>
                         <groupId>org.owasp</groupId>
                         <artifactId>dependency-check-maven</artifactId>
-                        <version>9.0.2</version>
+                        <version>9.0.7</version>
                         <configuration>
                             <skipProvidedScope>true</skipProvidedScope>
                             <skipTestScope>true</skipTestScope>


### PR DESCRIPTION
Use the NVD_API_KEY secret to access vulnerability definitions from the NVD database.