### PR TITLE
Build maintenance

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -18,4 +18,4 @@ jobs:
     name: Pull request success
     runs-on: ubuntu-latest
     steps:
-      - run: true
+      - run: "true"

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -14,16 +14,16 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout source
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: source
       - name: Download JavaDoc
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: javadoc
           path: javadoc
       - name: Checkout publish
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: publish
           ref: gh-pages
@@ -46,8 +46,8 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
         with:
           java-version: 8
           distribution: temurin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,8 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
         with:
           java-version: 8
           distribution: temurin
@@ -31,8 +31,8 @@ jobs:
     name: Publish Java artifact to Maven Central
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
         with:
           java-version: 8
           distribution: temurin

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,18 +21,18 @@ jobs:
   javadoc:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.checkout-ref }}
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
-          java-version: "17"
+          java-version: 17
           distribution: temurin
           cache: maven
       - name: Generate JavaDoc
         run: mvn --batch-mode -DskipTests verify
       - name: Upload JavaDoc
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: javadoc
           path: target/apidocs/
@@ -50,11 +50,11 @@ jobs:
           - java-version: "17"
             ssl-provider: JDK
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.checkout-ref }}
       - name: Set up JDK ${{ matrix.java-version }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java-version }}
           distribution: temurin

--- a/.github/workflows/vulnerability-scan.yml
+++ b/.github/workflows/vulnerability-scan.yml
@@ -6,22 +6,41 @@ on:
 
 jobs:
   scan:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
-          java-version: "17"
-          distribution: "temurin"
+          java-version: 17
+          distribution: temurin
           cache: maven
+      - name: Get Date
+        id: get-date
+        shell: bash
+        run: echo "datetime=$(/bin/date -u '+%Y%m%d%H')" >> $GITHUB_OUTPUT
+      - name: Restore cached Maven dependencies
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.m2/repository
+          # Using datetime in cache key as OWASP database may change, without the pom changing
+          key: ${{ runner.os }}-maven-${{ steps.get-date.outputs.datetime }}-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-${{ steps.get-date.outputs.datetime }}
+            ${{ runner.os }}-maven-
       - name: Scan
         env:
           NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
         run: mvn -P owasp dependency-check:check
       - name: "Archive dependency-check report"
-        if: success() || failure()
-        uses: actions/upload-artifact@v3
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
         with:
           name: dependency-check-report
           path: target/dependency-check-report.html
+      - name: Cache Maven dependencies
+        if: ${{ !cancelled() }}
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ steps.get-date.outputs.datetime }}-${{ hashFiles('**/pom.xml') }}

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.25.1</version>
+            <version>3.25.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -350,7 +350,7 @@
                     <plugin>
                         <groupId>org.owasp</groupId>
                         <artifactId>dependency-check-maven</artifactId>
-                        <version>9.0.8</version>
+                        <version>9.0.9</version>
                         <configuration>
                             <skipProvidedScope>true</skipProvidedScope>
                             <skipTestScope>true</skipTestScope>


### PR DESCRIPTION
- Cache dependency-check data to avoid unnecessary download of NVD data.
- Update GitHub actions to avoid deprecated Node 16 actions.