### PR TITLE
Use only v2.2.x packages in test chaincode

### DIFF
--- a/src/test/fixtures/chaincode/node/fabcar/package.json
+++ b/src/test/fixtures/chaincode/node/fabcar/package.json
@@ -8,32 +8,13 @@
         "npm": ">=5"
     },
     "scripts": {
-        "lint": "eslint .",
-        "pretest": "npm run lint",
-        "test": "nyc mocha --recursive",
         "start": "fabric-chaincode-node start"
     },
     "engineStrict": true,
     "author": "Hyperledger",
     "license": "Apache-2.0",
     "dependencies": {
-        "fabric-contract-api": "^2.1.0",
-        "fabric-shim": "^2.1.0"
-    },
-    "nyc": {
-        "exclude": [
-            "coverage/**",
-            "test/**"
-        ],
-        "reporter": [
-            "text-summary",
-            "html"
-        ],
-        "all": true,
-        "check-coverage": true,
-        "statements": 100,
-        "branches": 100,
-        "functions": 100,
-        "lines": 100
+        "fabric-contract-api": "~2.2",
+        "fabric-shim": "~2.2"
     }
 }

--- a/src/test/fixtures/chaincode/node/marbles0/package.json
+++ b/src/test/fixtures/chaincode/node/marbles0/package.json
@@ -12,6 +12,6 @@
 	"engine-strict": true,
 	"license": "Apache-2.0",
 	"dependencies": {
-		"fabric-shim": "^2.1.0"
+		"fabric-shim": "~2.2"
 	}
 }


### PR DESCRIPTION
Newer v2.5 chaincode packages are not compatible with the v2.2 chaincode container. The test chaincode previously used the latest v2.x release of the chaincode packages. This change restricts use to only v2.2.x packages, matching the Fabric v2.2 version used for testing.