### PR TITLE
Use `docker compose` instead of `docker-compose`

### DIFF
--- a/src/test/fixtures/generate.sh
+++ b/src/test/fixtures/generate.sh
@@ -10,7 +10,7 @@ rm -rf crypto-material/crypto-config
 
 cd docker-compose
 
-docker-compose -f docker-compose-cli.yaml up -d
+docker compose -f docker-compose-cli.yaml up -d
 docker exec -t cli cryptogen generate --config=/etc/hyperledger/config/crypto-config.yaml --output /etc/hyperledger/config/crypto-config
 docker exec -t cli configtxgen -profile ThreeOrgsOrdererGenesis -outputBlock /etc/hyperledger/config/genesis.block -channelID testchainid
 docker exec -t cli configtxgen -profile ThreeOrgsChannel -outputCreateChannelTx /etc/hyperledger/config/channel.tx -channelID mychannel
@@ -18,4 +18,4 @@ docker exec -t cli configtxgen -profile ThreeOrgsChannel -outputAnchorPeersUpdat
 docker exec -t cli configtxgen -profile ThreeOrgsChannel -outputAnchorPeersUpdate /etc/hyperledger/config/Org2MSPanchors.tx -channelID mychannel -asOrg Org2MSP
 docker exec -t cli cp /etc/hyperledger/fabric/core.yaml /etc/hyperledger/config
 docker exec -t cli sh /etc/hyperledger/config/rename_sk.sh
-docker-compose -f docker-compose-cli.yaml down --volumes
+docker compose -f docker-compose-cli.yaml down --volumes

--- a/src/test/java/scenario/ScenarioSteps.java
+++ b/src/test/java/scenario/ScenarioSteps.java
@@ -577,13 +577,13 @@ public class ScenarioSteps implements En {
     static void startFabric(boolean tls) throws Exception {
         createCryptoMaterial();
         String dockerComposeFile = tls ? DOCKER_COMPOSE_TLS_FILE : DOCKER_COMPOSE_FILE;
-        exec(DOCKER_COMPOSE_DIR, "docker-compose", "-f", dockerComposeFile, "-p", "node", "up", "-d");
+        exec(DOCKER_COMPOSE_DIR, "docker", "compose", "-f", dockerComposeFile, "-p", "node", "up", "-d");
         Thread.sleep(10000);
     }
 
     static void stopFabric(boolean tls) throws Exception {
         String dockerComposeFile = tls ? DOCKER_COMPOSE_TLS_FILE : DOCKER_COMPOSE_FILE;
-        exec(DOCKER_COMPOSE_DIR, "docker-compose", "-f", dockerComposeFile, "-p", "node", "down");
+        exec(DOCKER_COMPOSE_DIR, "docker", "compose", "-f", dockerComposeFile, "-p", "node", "down");
     }
 
     private static void createCryptoMaterial() throws Exception {


### PR DESCRIPTION
The old `docker-compose` command no longer exists in some environments and causes build failures. Instead use the replacement `docker compose` command.